### PR TITLE
Feature/wrapper invoice list invoice view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,13 @@
-import { useEffect } from 'react';
-import { useDispatch } from "react-redux";
+import React, { useEffect } from 'react';
+import {useDispatch, useSelector} from "react-redux";
 
 import { Home } from './pages/Home';
 import { fetchInvoices } from './store/invoicesActions';
-
+import {Nav} from "./components/Nav";
+import {NewInvoice} from "./components/newInvoice/NewInvoice";
 
 export const App = () => {
-
+  const modalStatus = useSelector(state => state.newFormModalStatus.status);
   const dispatch = useDispatch();
 
     useEffect(() => {
@@ -14,7 +15,16 @@ export const App = () => {
     },[dispatch]);
 
   return (
-    <Home />
+      <>
+        {!modalStatus &&
+            <>
+              <div className='flex flex-col lg:flex-row relative lg:justify-center'>
+                <Nav />
+                <Home/>
+              </div>
+            </>}
+        {modalStatus && <NewInvoice />}
+      </>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,10 @@
 import React, { useEffect } from 'react';
-import {useDispatch, useSelector} from "react-redux";
+import {useDispatch} from "react-redux";
 
 import { Home } from './pages/Home';
 import { fetchInvoices } from './store/invoicesActions';
-import {Nav} from "./components/Nav";
-import {NewInvoice} from "./components/newInvoice/NewInvoice";
 
 export const App = () => {
-  const modalStatus = useSelector(state => state.newFormModalStatus.status);
   const dispatch = useDispatch();
 
     useEffect(() => {
@@ -15,16 +12,7 @@ export const App = () => {
     },[dispatch]);
 
   return (
-      <>
-        {!modalStatus &&
-            <>
-              <div className='flex flex-col lg:flex-row relative lg:justify-center'>
-                <Nav />
-                <Home/>
-              </div>
-            </>}
-        {modalStatus && <NewInvoice />}
-      </>
+      <Home/>
   );
 }
 

--- a/src/UI/MainContentWrapper.js
+++ b/src/UI/MainContentWrapper.js
@@ -1,0 +1,8 @@
+export const MainContentWrapper = (props) => {
+
+    return (
+        // eslint-disable-next-line react/prop-types
+        <main className={`px-6 md:px-12 pt-8 md:pt-15 lg:pt-[72px] lg:ml-4 lg:px-0 ${props.styles}`} {...props}>{props.children}</main>
+    );
+};
+

--- a/src/UI/MainContentWrapper.js
+++ b/src/UI/MainContentWrapper.js
@@ -2,7 +2,7 @@ export const MainContentWrapper = (props) => {
 
     return (
         // eslint-disable-next-line react/prop-types
-        <main className={`px-6 md:px-12 pt-8 md:pt-15 lg:pt-[72px] lg:ml-4 lg:px-0 ${props.styles}`} {...props}>{props.children}</main>
+        <main className={`px-6 md:px-12 pt-8 md:pt-15 lg:pt-18 lg:ml-4 lg:px-0 ${props.styles}`} {...props}>{props.children}</main>
     );
 };
 

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import {Link, useNavigate, useParams} from 'react-router-dom';
 
 import { AlertModal } from '../components/AlertModal';
 import { deleteInvoice, editInvoice } from '../store/invoicesActions';
@@ -8,6 +8,7 @@ import { toggleInvoiceStatus } from '../store/invoicesSlice';
 import { closeNewFormModal, openNewFormModal } from '../store/newFormModalStatusSlice';
 import { Button } from '../UI/Button';
 import Label from '../UI/Label';
+import BackArrow from "../assets/icon-arrow-left.svg";
 
 const HeaderInvoiceView = () => {
 	const { invoiceId } = useParams();
@@ -45,44 +46,40 @@ const HeaderInvoiceView = () => {
 
 	return (
 		<>
-			<div className='hidden md:flex justify-between bg-light-100 dark:bg-dark-200 w-full items-center px-5 py-5 rounded-lg'>
-				<div className='md:flex items-center'>
+			<Link to={`/`}>
+				<div className='flex items-center my-6 mx-7 sm:mx-auto md:my-10 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
+					<img src={BackArrow} alt='back arrow' className='ml-2'></img>
+					<span className='text-dark-300 dark:text-light-100 text-md/1 ml-3'>Go back</span>
+				</div>
+			</Link>
+			<div className='flex items-center justify-between mx-7 bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5 sm:hidden'>
+				<span className='text-neutral-500 text-base/2'>Status</span>
+				<Label status={invoice.status} />
+			</div>
+			<div className="fixed sm:static flex items-center justify-between fixed bottom-0 bg-light-100 dark:bg-dark-200 w-full p-5 sm:px-8 rounded-lg">
+				<div className='hidden sm:flex items-center'>
 					<span className='text-neutral-500 text-base/2 md:mr-5'>Status </span>
 					<Label status={invoice.status} />
 				</div>
-				<div className='md:flex items-center gap-2'>
+				<div className="flex w-full sm:w-auto justify-between items-center">
 					<Button
-						styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white'
+						styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white hover:bg-neutral-200 px-6 mr-2'
 						title='Edit'
 						onClick={handleEditInvoice}/>
-					<Button styles='bg-red-500 text-white' title='Delete' onClick={showModal} />
+					<Button styles='bg-red-500 text-white hover:bg-danger-50 px-6 mr-2' title='Delete' onClick={showModal} />
 					<Button
-						styles='bg-primary-200 text-white'
+						styles='bg-primary-200 text-white hover:bg-danger-100 px-7'
 						id='markAsPaidButton'
 						title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
 						onClick={handleChangeStatusInvoice}/>
 				</div>
-			</div>
-			<div className='flex items-center justify-between fixed bottom-0 bg-light-100 dark:bg-dark-200 w-full p-5 md:hidden'>
-				<Button
-					styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white hover:bg-neutral-200 px-6'
-					title='Edit'
-					onClick={handleEditInvoice}/>
-				<Button styles='bg-red-500 text-white hover:bg-danger-50 px-6' title='Delete' onClick={showModal} />
-				<Button
-					styles='bg-primary-200 text-white hover:bg-danger-100 px-7'
-					id='markAsPaidButton'
-					title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
-					onClick={handleChangeStatusInvoice}/>
 			</div>
 			<AlertModal invoiceId={invoiceId}>
 				<Button
 					onClick={discardHandler}
 					styles='bg-neutral-100 dark:bg-dark-100 text-neutral-500 dark:text-neutral-200 hover:bg-neutral-200 dark:hover:bg-light-100 dark:hover:text-neutral-500'
 					title='Cancel'
-					type='button'
-				/>
-
+					type='button'/>
 				<Button onClick={handleDeleteInvoice} styles='bg-danger-150 text-light-100 hover:bg-danger-50 dark:hover:bg-danger-50' title='Delete' type='button' />
 			</AlertModal>
 		</>

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -58,10 +58,10 @@ const HeaderInvoiceView = () => {
 			</div>
 			<div className="fixed bottom-0 left-0 sm:static flex items-center justify-between bg-light-100 dark:bg-dark-200 w-full p-5 sm:px-8 rounded-lg">
 				<div className='hidden sm:flex items-center'>
-					<span className='text-neutral-500 text-base/2 md:mr-5'>Status </span>
+					<span className='text-neutral-500 text-base/2 sm:mr-5'>Status </span>
 					<Label status={invoice.status} />
 				</div>
-				<div className="flex w-full sm:w-auto justify-between items-center">
+				<div className="flex w-full sm:w-auto justify-center items-center">
 					<Button
 						styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white hover:bg-neutral-200 px-6 mr-2'
 						title='Edit'

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -68,7 +68,7 @@ const HeaderInvoiceView = () => {
 						onClick={handleEditInvoice}/>
 					<Button styles='bg-red-500 text-white hover:bg-danger-50 px-6 mr-2' title='Delete' onClick={showModal} />
 					<Button
-						styles='bg-primary-200 text-white hover:bg-danger-100 px-7'
+						styles='bg-primary-200 text-white hover:bg-danger-100 px-4 w-2/4'
 						id='markAsPaidButton'
 						title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
 						onClick={handleChangeStatusInvoice}/>

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -47,7 +47,7 @@ const HeaderInvoiceView = () => {
 	return (
 		<>
 			<Link to={`/`}>
-				<div className='flex items-center mb-8 sm:mx-auto md:my-10 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
+				<div className='flex items-center mb-8 md:mb-8 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
 					<img src={BackArrow} alt='back arrow' className='ml-2'></img>
 					<span className='text-dark-300 dark:text-light-100 text-md/1 ml-3'>Go back</span>
 				</div>

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -47,16 +47,16 @@ const HeaderInvoiceView = () => {
 	return (
 		<>
 			<Link to={`/`}>
-				<div className='flex items-center my-6 mx-7 sm:mx-auto md:my-10 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
+				<div className='flex items-center mb-8 sm:mx-auto md:my-10 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
 					<img src={BackArrow} alt='back arrow' className='ml-2'></img>
 					<span className='text-dark-300 dark:text-light-100 text-md/1 ml-3'>Go back</span>
 				</div>
 			</Link>
-			<div className='flex items-center justify-between mx-7 bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5 sm:hidden'>
+			<div className='flex items-center justify-between bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5 sm:hidden'>
 				<span className='text-neutral-500 text-base/2'>Status</span>
 				<Label status={invoice.status} />
 			</div>
-			<div className="fixed sm:static flex items-center justify-between fixed bottom-0 bg-light-100 dark:bg-dark-200 w-full p-5 sm:px-8 rounded-lg">
+			<div className="fixed bottom-0 left-0 sm:static flex items-center justify-between bg-light-100 dark:bg-dark-200 w-full p-5 sm:px-8 rounded-lg">
 				<div className='hidden sm:flex items-center'>
 					<span className='text-neutral-500 text-base/2 md:mr-5'>Status </span>
 					<Label status={invoice.status} />

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -52,7 +52,7 @@ const HeaderInvoiceView = () => {
 					<span className='text-dark-300 dark:text-light-100 text-md/1 ml-3'>Go back</span>
 				</div>
 			</Link>
-			<div className='flex items-center justify-between bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5 sm:hidden'>
+			<div className='sm:hidden flex items-center justify-between bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5'>
 				<span className='text-neutral-500 text-base/2'>Status</span>
 				<Label status={invoice.status} />
 			</div>
@@ -68,7 +68,7 @@ const HeaderInvoiceView = () => {
 						onClick={handleEditInvoice}/>
 					<Button styles='bg-red-500 text-white hover:bg-danger-50 px-6 mr-2' title='Delete' onClick={showModal} />
 					<Button
-						styles='bg-primary-200 text-white hover:bg-danger-100 px-4 w-2/4'
+						styles='bg-primary-200 text-white hover:bg-danger-100 w-36 md:px-4'
 						id='markAsPaidButton'
 						title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
 						onClick={handleChangeStatusInvoice}/>

--- a/src/components/HeaderInvoiceView.js
+++ b/src/components/HeaderInvoiceView.js
@@ -50,41 +50,31 @@ const HeaderInvoiceView = () => {
 					<span className='text-neutral-500 text-base/2 md:mr-5'>Status </span>
 					<Label status={invoice.status} />
 				</div>
-
 				<div className='md:flex items-center gap-2'>
 					<Button
 						styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white'
 						title='Edit'
-						onClick={handleEditInvoice}
-					/>
-
+						onClick={handleEditInvoice}/>
 					<Button styles='bg-red-500 text-white' title='Delete' onClick={showModal} />
-
 					<Button
 						styles='bg-primary-200 text-white'
 						id='markAsPaidButton'
 						title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
-						onClick={handleChangeStatusInvoice}
-					/>
+						onClick={handleChangeStatusInvoice}/>
 				</div>
 			</div>
 			<div className='flex items-center justify-between fixed bottom-0 bg-light-100 dark:bg-dark-200 w-full p-5 md:hidden'>
 				<Button
-					styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white'
+					styles='bg-neutral-100 text-neutral-500 dark:bg-dark-100 dark:text-white hover:bg-neutral-200 px-6'
 					title='Edit'
-					onClick={handleEditInvoice}
-				/>
-
-				<Button styles='bg-red-500' title='Delete' onClick={showModal} />
-
+					onClick={handleEditInvoice}/>
+				<Button styles='bg-red-500 text-white hover:bg-danger-50 px-6' title='Delete' onClick={showModal} />
 				<Button
-					styles='bg-primary-200 text-white'
+					styles='bg-primary-200 text-white hover:bg-danger-100 px-7'
 					id='markAsPaidButton'
 					title={invoice.status === 'paid' ? 'Mark as Unpaid' : 'Mark as Paid'}
-					onClick={handleChangeStatusInvoice}
-				/>
+					onClick={handleChangeStatusInvoice}/>
 			</div>
-
 			<AlertModal invoiceId={invoiceId}>
 				<Button
 					onClick={discardHandler}

--- a/src/components/InvoiceDetails.js
+++ b/src/components/InvoiceDetails.js
@@ -64,7 +64,7 @@ const InvoiceDetails = () => {
   };
 
   return (
-    <div className='flex-col my-5 mx-7 bg-light-100 dark:bg-dark-200 rounded-lg mb-20 p-5 sm:m-0 sm:mt-5 sm:px-10 sm:py-12'>
+    <div className='flex-col my-5 bg-light-100 dark:bg-dark-200 rounded-lg mb-20 p-5 sm:m-0 sm:mt-5 sm:px-10 sm:py-12'>
       <div className='md:flex flex-row md:justify-between md:pb-5'>
         <ul className='pb-7 md:pb-0'>
           <li className='text-md/2'>

--- a/src/components/InvoiceDetails.js
+++ b/src/components/InvoiceDetails.js
@@ -64,10 +64,7 @@ const InvoiceDetails = () => {
   };
 
   return (
-    <div
-      className='flex-col my-5 mx-7 bg-light-100 dark:bg-dark-200 
-    rounded-lg mb-20 p-5 md:m-0 md:mt-5 md:px-10 md:py-12'
-    >
+    <div className='flex-col my-5 mx-7 bg-light-100 dark:bg-dark-200 rounded-lg mb-20 p-5 sm:m-0 sm:mt-5 sm:px-10 sm:py-12'>
       <div className='md:flex flex-row md:justify-between md:pb-5'>
         <ul className='pb-7 md:pb-0'>
           <li className='text-md/2'>

--- a/src/components/InvoiceDetails.js
+++ b/src/components/InvoiceDetails.js
@@ -64,7 +64,7 @@ const InvoiceDetails = () => {
   };
 
   return (
-    <div className='flex-col my-5 bg-light-100 dark:bg-dark-200 rounded-lg mb-20 p-5 sm:m-0 sm:mt-5 sm:px-10 sm:py-12'>
+    <div className='flex-col mt-5 md:mt-6 mb-20 md:mb-0 p-5 md:p-8 bg-light-100 dark:bg-dark-200 rounded-lg '>
       <div className='md:flex flex-row md:justify-between md:pb-5'>
         <ul className='pb-7 md:pb-0'>
           <li className='text-md/2'>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -5,6 +5,8 @@ import { HeaderHome } from '../components/HeaderHome';
 import { InvoiceList } from '../components/InvoiceList';
 import { Nav } from '../components/Nav';
 import { NewInvoice } from "../components/newInvoice/NewInvoice";
+import {MainContentWrapper} from "../UI/MainContentWrapper";
+import React from "react";
 
 
 export const Home = () => {
@@ -20,10 +22,10 @@ export const Home = () => {
 				<>
 					<div className='flex flex-col lg:flex-row relative lg:justify-center'>
 						<Nav />
-						<main className='px-6 md:px-12 pt-8 md:pt-15 lg:pt[72px] lg:ml-4 lg:px-0'>
+						<MainContentWrapper>
 							<HeaderHome />
 							<InvoiceList />
-						</main>
+						</MainContentWrapper>
 					</div>
 				</>}
 			{modalStatus && <NewInvoice />}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,35 +1,22 @@
-//Future todo - create Wrapper component for DRY rule
 import {useSelector} from 'react-redux';
 
 import { HeaderHome } from '../components/HeaderHome';
 import { InvoiceList } from '../components/InvoiceList';
-import { Nav } from '../components/Nav';
-import { NewInvoice } from "../components/newInvoice/NewInvoice";
 import {MainContentWrapper} from "../UI/MainContentWrapper";
 import React from "react";
 
 
 export const Home = () => {
 	const loadingStatus = useSelector(state => state.invoices.status);
-	const modalStatus = useSelector(state => state.newFormModalStatus.status);
 
 	if (loadingStatus === 'loading') {
 		return <div>LOADING</div>;
 	}
 	return (
-		<>
-			{!modalStatus &&
-				<>
-					<div className='flex flex-col lg:flex-row relative lg:justify-center'>
-						<Nav />
-						<MainContentWrapper>
-							<HeaderHome />
-							<InvoiceList />
-						</MainContentWrapper>
-					</div>
-				</>}
-			{modalStatus && <NewInvoice />}
-		</>
+		<MainContentWrapper>
+			<HeaderHome />
+			<InvoiceList />
+		</MainContentWrapper>
 	);
 }
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -20,7 +20,7 @@ export const Home = () => {
 				<>
 					<div className='flex flex-col lg:flex-row relative lg:justify-center'>
 						<Nav />
-						<main className='px-6 md:px-12 pt-8 md:pt-15'>
+						<main className='px-6 md:px-12 pt-8 md:pt-15 lg:pt[72px] lg:ml-4 lg:px-0'>
 							<HeaderHome />
 							<InvoiceList />
 						</main>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -19,7 +19,6 @@ export const Home = () => {
 		<>
 			{!modalStatus &&
 				<div className='flex flex-col lg:flex-row relative lg:justify-center'>
-					<Nav />
 					<MainContentWrapper>
 						<HeaderHome />
 						<InvoiceList />

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -19,6 +19,7 @@ export const Home = () => {
 		<>
 			{!modalStatus &&
 				<div className='flex flex-col lg:flex-row relative lg:justify-center'>
+					<Nav/>
 					<MainContentWrapper>
 						<HeaderHome />
 						<InvoiceList />

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,22 +1,32 @@
 import {useSelector} from 'react-redux';
 
+import {Nav} from "../components/Nav";
+import { MainContentWrapper} from "../UI/MainContentWrapper";
 import { HeaderHome } from '../components/HeaderHome';
 import { InvoiceList } from '../components/InvoiceList';
-import {MainContentWrapper} from "../UI/MainContentWrapper";
+import {NewInvoice} from "../components/newInvoice/NewInvoice";
 import React from "react";
 
 
 export const Home = () => {
 	const loadingStatus = useSelector(state => state.invoices.status);
+	const modalStatus = useSelector(state => state.newFormModalStatus.status);
 
 	if (loadingStatus === 'loading') {
 		return <div>LOADING</div>;
 	}
 	return (
-		<MainContentWrapper>
-			<HeaderHome />
-			<InvoiceList />
-		</MainContentWrapper>
+		<>
+			{!modalStatus &&
+				<div className='flex flex-col lg:flex-row relative lg:justify-center'>
+					<Nav />
+					<MainContentWrapper>
+						<HeaderHome />
+						<InvoiceList />
+					</MainContentWrapper>
+				</div>}
+			{modalStatus && <NewInvoice />}
+		</>
 	);
 }
 

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -1,6 +1,6 @@
 // import React from "react";
 import { useSelector } from 'react-redux';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import HeaderInvoiceView from '../components/HeaderInvoiceView';
 import InvoiceDetails from '../components/InvoiceDetails';
@@ -11,12 +11,9 @@ import {MainContentWrapper} from "../UI/MainContentWrapper";
 const InvoiceView = () => {
 	const { invoiceId } = useParams();
 	const invoice = useSelector(state => selectInvoiceById(state, invoiceId));
-
-	if (!invoice) {
-		return <div>Loading...</div>;
-	}
-
 	const modalStatus = useSelector(state => state.newFormModalStatus.status);
+
+	if (!invoice) return <div>Loading...</div>;
 
 	return (
 		<div inert={modalStatus ? '' : undefined}>

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -22,18 +22,8 @@ const InvoiceView = () => {
 	return (
 		<div inert={modalStatus ? '' : undefined}>
 			<Nav />
-				<Link to={`/`}>
-					<div className='flex items-center my-6 mx-7 md:mx-auto md:my-10 md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
-						<img src={BackArrow} alt='back arrow' className='ml-2'></img>
-						<span className='text-dark-300 dark:text-light-100 text-md/1 ml-3'>Go back</span>
-					</div>
-				</Link>
 				<div className='text-dark-300 dark:text-light-100 flex items-center justify-center my-0'>
-					<div className='flex flex-col w-full md:w-4/5 md:m-0 xl:w-1/2 2xl:w-1/3'>
-						<div className='flex items-center justify-between mx-7 bg-light-100 dark:bg-dark-200 shadow-3xl rounded-lg p-5 md:hidden'>
-							<span className='text-neutral-500 text-base/2'>Status </span>
-							<Label status={invoice.status} />
-						</div>
+					<div className='flex flex-col w-full sm:w-4/5 md:m-0 xl:w-1/2'>
 						<HeaderInvoiceView />
 						<InvoiceDetails />
 					</div>

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -6,6 +6,7 @@ import HeaderInvoiceView from '../components/HeaderInvoiceView';
 import InvoiceDetails from '../components/InvoiceDetails';
 import { Nav } from '../components/Nav';
 import { selectInvoiceById } from '../store/invoicesSlice';
+import {MainContentWrapper} from "../UI/MainContentWrapper";
 
 const InvoiceView = () => {
 	const { invoiceId } = useParams();
@@ -21,10 +22,10 @@ const InvoiceView = () => {
 		<div inert={modalStatus ? '' : undefined}>
 			<div className='flex flex-col lg:flex-row relative lg:justify-center'>
 				<Nav />
-				<main className='px-6 md:px-12 pt-8 md:pt-15 lg:pt[72px] lg:px-0 lg:ml-4 lg:w-[788px]'>
+				<MainContentWrapper styles='lg:w-[788px]'>
 						<HeaderInvoiceView />
 						<InvoiceDetails />
-				</main>
+				</MainContentWrapper>
 			</div>
 		</div>
 	);

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -19,7 +19,7 @@ const InvoiceView = () => {
 		<div inert={modalStatus ? '' : undefined}>
 			<div className='flex flex-col lg:flex-row relative lg:justify-center'>
 				<Nav />
-				<MainContentWrapper styles='lg:w-[788px]'>
+				<MainContentWrapper styles='lg:w-2xl'>
 						<HeaderInvoiceView />
 						<InvoiceDetails />
 				</MainContentWrapper>

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -21,7 +21,7 @@ const InvoiceView = () => {
 		<div inert={modalStatus ? '' : undefined}>
 			<div className='flex flex-col lg:flex-row relative lg:justify-center'>
 				<Nav />
-				<main className='px-6 md:px-12 pt-8 md:pt-15'>
+				<main className='px-6 md:px-12 pt-8 md:pt-15 lg:pt[72px] lg:px-0 lg:ml-4 lg:w-[788px]'>
 						<HeaderInvoiceView />
 						<InvoiceDetails />
 				</main>

--- a/src/pages/InvoiceView.js
+++ b/src/pages/InvoiceView.js
@@ -2,12 +2,10 @@
 import { useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 
-import BackArrow from '../assets/icon-arrow-left.svg';
 import HeaderInvoiceView from '../components/HeaderInvoiceView';
 import InvoiceDetails from '../components/InvoiceDetails';
 import { Nav } from '../components/Nav';
 import { selectInvoiceById } from '../store/invoicesSlice';
-import Label from '../UI/Label';
 
 const InvoiceView = () => {
 	const { invoiceId } = useParams();
@@ -21,13 +19,13 @@ const InvoiceView = () => {
 
 	return (
 		<div inert={modalStatus ? '' : undefined}>
-			<Nav />
-				<div className='text-dark-300 dark:text-light-100 flex items-center justify-center my-0'>
-					<div className='flex flex-col w-full sm:w-4/5 md:m-0 xl:w-1/2'>
+			<div className='flex flex-col lg:flex-row relative lg:justify-center'>
+				<Nav />
+				<main className='px-6 md:px-12 pt-8 md:pt-15'>
 						<HeaderInvoiceView />
 						<InvoiceDetails />
-					</div>
-				</div>
+				</main>
+			</div>
 		</div>
 	);
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
 			width: {
 				22: '5.63rem', // 90 px for button in mobile view
 				46: '9.375rem', // 150 px for button in desktop view
+				'2xl': '49rem', // 788 px for the mainContentWrapper
 			},
 
 			padding: {
@@ -28,6 +29,7 @@ module.exports = {
 				14.5: '3.6875rem', //59px
 				15: '3.8125rem', // 61px
 				39: '9.9375rem', //159px
+				18: '4.5rem', //72px
 			},
 
 			fontFamily: {


### PR DESCRIPTION
1. I managed to unify the Home and InvoiceView so now the content on both pages is rendered in the same place. I made it through creating a new wrapping component with certain positioning, which encapsulate HeaderHome and Invoice List on the home page and HeaderInvoiceView + InvoiceDetails on the InvoiceView page. I removed unnecessary paddings/margins etc on several tags from InvoiceView page + I set the fixed width for the HeaderInvoiceView for desktop (the width is the same as width of the content on the Home page), which caused that also invoice details stretched to this certain width. 
2. If the case was that distances between borders of content in home and invoiceView and the screen were slightly different (eg. in desktop view the space between content in home and top of the screen was 78px, in invoice view 65px) I averaged them for the sake of having the content on both pages in the same position.
3. 5. Also, I removed the duplicated code that was rendering buttons in HeaderInvoiceView twice 
6. I moved code that was representing "go back" button and status of the invoice from InvoiceView to the HeaderInvoiceView
4. For the InvoiceView I changed the breakpoint from which the design switches from mobile to tablet - before it changed after 768 (md), now after 640px (sm).  I think it more intuitive and readable now, especially when we consider the placement of the buttons.
5. I added hoover on buttons + the "mark as paid" button got fixed width (now clicking on it and changing it's content doesn't cause the whole design to change it's width)
